### PR TITLE
Set prefix to download files in ext/gtest instead of ext

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ set(EXT_PROJECTS_DIR ${PROJECT_SOURCE_DIR}/ext)
 #file(GLOB SRC_FILES ${PROJECT_SOURCE_DIR}/src/*.cpp)
 #add_library(${PROJECT_LIB_NAME} ${SRC_FILES})
 
-SET_DIRECTORY_PROPERTIES(PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/ext)
 add_subdirectory(${EXT_PROJECTS_DIR}/gtest)
 
 #-------------------
@@ -38,7 +37,7 @@ add_dependencies(${PROJECT_TEST_NAME} googletest)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
 	target_link_libraries(${PROJECT_TEST_NAME} pthread)
-	target_link_libraries(${PROJECT_TEST_NAME} 
+	target_link_libraries(${PROJECT_TEST_NAME}
 		${GTEST_LIBS_DIR}/libgtest.a
 		${GTEST_LIBS_DIR}/libgtest_main.a
 	)
@@ -53,9 +52,5 @@ else()
 	       optimized ${GTEST_LIBS_DIR}/ReleaseLibs/${CMAKE_FIND_LIBRARY_PREFIXES}gtest_main${CMAKE_FIND_LIBRARY_SUFFIXES}
 	)
 endif()
- 
+
 add_test(test1 ${PROJECT_TEST_NAME})
-
- 
- 
-

--- a/ext/gtest/CMakeLists.txt
+++ b/ext/gtest/CMakeLists.txt
@@ -2,13 +2,12 @@ cmake_minimum_required(VERSION 2.8.8)
 project(gtest_builder C CXX)
 include(ExternalProject)
 
-set(OWN_G_PREFIX "${CMAKE_BINARY_DIR}/ext/gtest")
-
 ExternalProject_Add(googletest
     SVN_REPOSITORY http://googletest.googlecode.com/svn/trunk
     CMAKE_ARGS -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=DebugLibs
                -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE:PATH=ReleaseLibs
                -Dgtest_force_shared_crt=ON
+     PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
 # Disable install step
     INSTALL_COMMAND ""
 )


### PR DESCRIPTION
Prefix line made better sense in ext/gtest/CMakeLists.txt

I also adjusted the code so that it output the src and tmp directories inside ext/gtest so it wouldn't conflict with other external projexts.
